### PR TITLE
Add paged replies

### DIFF
--- a/bot/config/default.yml
+++ b/bot/config/default.yml
@@ -26,6 +26,14 @@ discord:
     # The command prefix (in case there is another bot running, you can change the prefix to prevent conflicts)
     prefix: "!"
 
+    paged_reply:
+      # Default reactions to browse through a paged reply, can be overridden separately by a command
+      reactions:
+        first: ⏮
+        last: ⏭
+        previous: ◀
+        next: ▶
+
 
 database:
   # The database provider (only mongodb is supported, use false to disable)

--- a/bot/locales/en-US/module.general.json
+++ b/bot/locales/en-US/module.general.json
@@ -22,7 +22,8 @@
     "response-command-not-recognized": "The command '{{command}}' is not recognized. Type `{{help}}` to see the list of commands.",
     "response-command-not-allowed": "Unfortunately, you are not allowed to access the command '{{command}}'. Type `{{help}}` to see the list of available commands.",
     "response-single-help": "{{help}}",
-    "response-all-help": "{{list}}\n\nType `{{help}} <command>` for information about a specific command."
+    "response-all-help": "{{list}}\n\nType `{{help}} <command>` for information about a specific command.",
+    "response-all-help-paged": "{{list}}\n\nType `{{help}} <command>` for information about a specific command.\n\n*Help page {{current_page}}/{{total_pages}}*"
   },
   "info": {
     "_meta": {

--- a/bot/middleware/Cache.js
+++ b/bot/middleware/Cache.js
@@ -2,6 +2,8 @@
 
 const hash = require('object-hash');
 
+const DiscordReplyMessage = require('../modules/DiscordReplyMessage');
+
 const Middleware = require('./Middleware');
 
 
@@ -54,7 +56,7 @@ class CacheMiddleware extends Middleware {
 
         const cachedObj = await bot.getCache().get(`${command}-exec`, id);
         if (cachedObj) {
-            response.reply = cachedObj;
+            response.reply = DiscordReplyMessage.deserialize(cachedObj);
         }
         return response;
     }
@@ -68,7 +70,7 @@ class CacheMiddleware extends Middleware {
 
         const cachedObj = await bot.getCache().get(`${command}-exec`, id);
         if (!cachedObj) {
-            await bot.getCache().set(`${command}-exec`, id, options.duration, response.reply);
+            await bot.getCache().set(`${command}-exec`, id, options.duration, response.reply.serialize());
         }
         return response;
     }

--- a/bot/middleware/internal/PagedReply.js
+++ b/bot/middleware/internal/PagedReply.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const Middleware = require('../Middleware');
+
+const DiscordReplyMessage = require('../../modules/DiscordReplyMessage');
+
+
+const replyCacheTable = 'paged-reply';
+const replyReactionTtl = 15 * 60 * 1000; // 15 minutes
+
+
+/**
+ * Gets the cache message id.
+ * @param {Message} message - The Discord message.
+ * @returns {string} The cache message id.
+ */
+function getCacheMessageId(message) {
+    return `${message.channel.id}.${message.id}`;
+}
+
+/**
+ * Constructs a global on reaction function that gets called whenever a reaction is added to or removed from a Discord message.
+ * This global function prevents many reaction hooks for Discord.js as it will only be called once.
+ * @param {Bot} bot - The bot instance.
+ * @returns {function<Promise<MessageReaction, User>>} The function.
+ */
+function constructGlobalOnReaction(bot) {
+    return async (reaction, user) => {
+        if (user.bot) {
+            // Ignore bot reactions, for safety reasons
+            return;
+        }
+
+        if (reaction.message.author.id !== bot.getClient().user.id) {
+            // Ignore reactions on messages that are not ours
+            return;
+        }
+
+        const cache = bot.getCache();
+
+        const cacheObj = await cache.get(replyCacheTable, getCacheMessageId(reaction.message));
+        if (!cacheObj.message) {
+            // No cached pages
+            return;
+        }
+        const message = DiscordReplyMessage.deserialize(cacheObj.message);
+
+        if (user.id !== cacheObj.author) {
+            // It's not the original author reacting to the message
+            return;
+        }
+
+        const replyMessage = message.constructDiscordMessage(reaction.emoji.toString(), true);
+        if (replyMessage) {
+            return Promise.all([
+                reaction.message.edit(...replyMessage),
+                cache.set(replyCacheTable, getCacheMessageId(reaction.message), replyReactionTtl, { message: message.serialize(), author: cacheObj.author })
+            ]);
+        }
+    };
+}
+
+/**
+ * A middleware that adds support for a paged reply.
+ */
+class PagedReplyMiddleware extends Middleware {
+    /**
+     * Creates a new middleware that adds support for a paged reply.
+     * @param {Bot} bot - The bot instance.
+     * @param {DiscordCommand} command - The Discord command.
+     * @param {Object<string, *>} [options] - Additional options for the middleware.
+     */
+    constructor(bot, command, options) {
+        super(bot, 'pagedReply', command, options);
+    }
+
+    async onReplyPosted(response, message) {
+        if (!response.reply || !response.reply.hasPages()) {
+            // The response doesn't have a reply or the reply doesn't have pages
+            return response;
+        }
+
+        const bot = this.getBot();
+        if (!this._onReaction) {
+            this._onReaction = constructGlobalOnReaction(bot);
+            const client = bot.getClient();
+            client.on('messageReactionAdd', this._onReaction);
+            client.on('messageReactionRemove', this._onReaction);
+        }
+
+        if (!response.reply.pageEmojis) {
+            response.reply.pageEmojis = bot.getConfig().get('/discord.commands.paged_reply.reactions').raw();
+        }
+
+        const pageEmojis = response.reply.pageEmojis;
+        await message.react(pageEmojis.first);
+        await message.react(pageEmojis.previous);
+        await message.react(pageEmojis.next);
+        await message.react(pageEmojis.last);
+
+        const cache = bot.getCache();
+        return cache.set(replyCacheTable, getCacheMessageId(message), replyReactionTtl, { message: response.reply.serialize(), author: response.getRequest().getMessage().author.id });
+    }
+}
+
+module.exports = PagedReplyMiddleware;

--- a/bot/middleware/internal/PagedReply.js
+++ b/bot/middleware/internal/PagedReply.js
@@ -88,15 +88,22 @@ class PagedReplyMiddleware extends Middleware {
             client.on('messageReactionRemove', this._onReaction);
         }
 
-        if (!response.reply.pageEmojis) {
-            response.reply.pageEmojis = bot.getConfig().get('/discord.commands.paged_reply.reactions').raw();
-        }
+        const emojis = response.reply.pages.map(p => p.emoji).filter(e => e);
+        if (!emojis) {
+            if (!response.reply.pageEmojis) {
+                response.reply.pageEmojis = bot.getConfig().get('/discord.commands.paged_reply.reactions').raw();
+            }
 
-        const pageEmojis = response.reply.pageEmojis;
-        await message.react(pageEmojis.first);
-        await message.react(pageEmojis.previous);
-        await message.react(pageEmojis.next);
-        await message.react(pageEmojis.last);
+            const pageEmojis = response.reply.pageEmojis;
+            await message.react(pageEmojis.first);
+            await message.react(pageEmojis.previous);
+            await message.react(pageEmojis.next);
+            await message.react(pageEmojis.last);
+        } else {
+            for (const emoji of emojis) {
+                await message.react(emoji); // eslint-disable-line no-await-in-loop
+            }
+        }
 
         const cache = bot.getCache();
         return cache.set(replyCacheTable, getCacheMessageId(message), replyReactionTtl, { message: response.reply.serialize(), author: response.getRequest().getMessage().author.id });

--- a/bot/middleware/internal/ReplyWithMentions.js
+++ b/bot/middleware/internal/ReplyWithMentions.js
@@ -21,6 +21,25 @@ class ReplyWithMentionsMiddleware extends Middleware {
         };
     }
 
+    _addMentions(pages, channelType, mentions) {
+        for (let i = 0; i < pages.length; i++) {
+            if (!pages[i].text.includes(mentions)) {
+                // Only apply the mentions when it hasn't been added manually already
+                if (channelType === 'dm') {
+                    pages[i].text = this.getBot().getLocalizer().t('middleware.defaults:reply-with-mentions.response-dm', {
+                        mentions,
+                        message: pages[i].text
+                    });
+                } else {
+                    pages[i].text = this.getBot().getLocalizer().t('middleware.defaults:reply-with-mentions.response-public', {
+                        mentions,
+                        message: pages[i].text
+                    });
+                }
+            }
+        }
+    }
+
     async onReplyConstructed(response) {
         if (!response.reply) {
             return response;
@@ -31,21 +50,7 @@ class ReplyWithMentionsMiddleware extends Middleware {
             return response;
         }
 
-        if (!response.reply.text.includes(mentions)) {
-            // Only apply the mentions when it hasn't been added manually already
-            if (response.getTargetChannel().type === 'dm') {
-                response.reply.text = this.getBot().getLocalizer().t('middleware.defaults:reply-with-mentions.response-dm', {
-                    mentions,
-                    message: response.reply.text
-                });
-            } else {
-                response.reply.text = this.getBot().getLocalizer().t('middleware.defaults:reply-with-mentions.response-public', {
-                    mentions,
-                    message: response.reply.text
-                });
-            }
-        }
-
+        this._addMentions(response.reply.pages, response.getTargetChannel().type, mentions);
         return response;
     }
 }

--- a/bot/modules/DiscordCommand.js
+++ b/bot/modules/DiscordCommand.js
@@ -6,6 +6,7 @@ const random = require('random-js')();
 const Throttle = require('../middleware/Throttle');
 const MiddlewareError = require('../middleware/MiddlewareError');
 const CorrectNumberOfParameters = require('../middleware/internal/CorrectNumberOfParameters');
+const PagedReply = require('../middleware/internal/PagedReply');
 const ParameterError = require('../middleware/internal/ParameterError');
 const PermissionError = require('../middleware/internal/PermissionError');
 const ReplyWithMentions = require('../middleware/internal/ReplyWithMentions');
@@ -106,6 +107,7 @@ class DiscordCommand extends DiscordHook {
         this.setMiddleware(new RestrictPermissions(bot, this));
         this.setMiddleware(new Throttle(bot, this));
         this.setMiddleware(new CorrectNumberOfParameters(bot, this));
+        this.setMiddleware(new PagedReply(bot, this));
         this.setMiddleware(new ReplyWithMentions(bot, this));
     }
 
@@ -221,10 +223,7 @@ class DiscordCommand extends DiscordHook {
         // Send message
         let replyMessage;
         if (response.reply) {
-            replyMessage = await response.getTargetChannel().send(response.reply.text, {
-                embed: response.reply.embed,
-                file: response.reply.file
-            });
+            replyMessage = await response.getTargetChannel().send(...response.reply.constructDiscordMessage());
         }
 
         if (replyMessage) {

--- a/bot/modules/DiscordReplyMessage.js
+++ b/bot/modules/DiscordReplyMessage.js
@@ -93,28 +93,30 @@ class DiscordReplyMessage {
 
         // Determine the correct page to construct
         if (typeof (page) === 'string') {
-            let id = this.pages.find(p => p.emoji === page);
-            if (!id) {
-                switch (page) {
-                    case this.pageEmojis.first:
-                        id = 0;
-                        break;
-                    case this.pageEmojis.last:
-                        id = this.pages.length - 1;
-                        break;
-                    case this.pageEmojis.previous:
-                        id = this.activePage - 1;
-                        break;
-                    case this.pageEmojis.next:
-                        id = this.activePage + 1;
-                        break;
-                    default:
-                        break; // Make linter happy
+            let id = this.pages.findIndex(p => p.emoji === page);
+            if (id < 0) {
+                if (this.pageEmojis) {
+                    switch (page) {
+                        case this.pageEmojis.first:
+                            id = 0;
+                            break;
+                        case this.pageEmojis.last:
+                            id = this.pages.length - 1;
+                            break;
+                        case this.pageEmojis.previous:
+                            id = this.activePage - 1;
+                            break;
+                        case this.pageEmojis.next:
+                            id = this.activePage + 1;
+                            break;
+                        default:
+                            break; // Make linter happy
+                    }
                 }
-            }
-            if (id < 0 || id >= this.pages.length) {
-                // Out of bounds
-                return undefined;
+                if (id >= this.pages.length) {
+                    // Out of bounds
+                    return undefined;
+                }
             }
             page = id;
         }

--- a/bot/modules/DiscordReplyMessage.js
+++ b/bot/modules/DiscordReplyMessage.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const DiscordReplyPage = require('./DiscordReplyPage');
+
 
 /**
  * Represents a reply message for Discord.
@@ -7,21 +9,21 @@
 class DiscordReplyMessage {
     /**
      * Creates a new reply message.
-     * @param {string} text - The reply message text.
+     * @param {string|DiscordReplyPage[]} content - The reply message text or an array of reply pages.
      * @param {Object} [options] - The reply message options.
      */
-    constructor(text, options) {
+    constructor(content, options) {
         /**
-         * The message contents.
-         * @type {string}
+         * The reply pages, if any.
+         * @type {DiscordReplyPage[]}
          */
-        this.text = text;
+        this.pages = [];
 
         /**
-         * The embedded message.
-         * @type {RichEmbed|undefined}
+         * The active page.
+         * @type {number}
          */
-        this.embed = options && options.embed;
+        this.activePage = (options && options.activePage) || 0;
 
         /**
          * The embedded file.
@@ -30,12 +32,112 @@ class DiscordReplyMessage {
         this.file = options && options.file;
 
         /**
+         * The associated page browse emojis.
+         * @type {Object}
+         */
+        this.pageEmojis = options && options.pageEmojis;
+
+        /**
          * Extra data.
          * @type {*}
          */
         this.data = options && options.data;
 
-        // TODO: support splitting messages somehow...
+        if (typeof (content) === 'string') {
+            this.pages = [new DiscordReplyPage(content, options)];
+        } else if (Array.isArray(content)) {
+            this.pages = content.slice(0);
+        }
+    }
+
+    /**
+     * Serializes this reply.
+     * @returns {Object} The serialized object.
+     */
+    serialize() {
+        return {
+            pages: this.pages.slice(),
+            activePage: this.activePage,
+            file: this.file,
+            pageEmojis: this.pageEmojis,
+            data: this.data
+        };
+    }
+
+    /**
+     * Deserializes the reply.
+     * @param {Object} obj - The object.
+     * @returns {DiscordReplyMessage} The deserialized reply.
+     */
+    static deserialize(obj) {
+        return new DiscordReplyMessage(obj.pages.slice(0), {
+            activePage: obj.activePage,
+            file: obj.file,
+            pageEmojis: obj.pageEmojis,
+            data: obj.data
+        });
+    }
+
+    /**
+     * Constructs a Discord message to be sent with the .send() function on channels.
+     * @param {number|string|undefined} [page] - The page to send (page id, custom page emoji or browse emoji), defaults to the active page if undefined.
+     * @param {boolean} [setActive = false] - Whether or not to set the active page to the one that has just been constructed.
+     * @returns {[string,{}]|undefined} The message, or undefined if no message is available.
+     */
+    constructDiscordMessage(page, setActive = false) {
+        page = page || this.activePage;
+
+        if (this.pages.length === 0) {
+            return undefined;
+        }
+
+        // Determine the correct page to construct
+        if (typeof (page) === 'string') {
+            let id = this.pages.find(p => p.emoji === page);
+            if (!id) {
+                switch (page) {
+                    case this.pageEmojis.first:
+                        id = 0;
+                        break;
+                    case this.pageEmojis.last:
+                        id = this.pages.length - 1;
+                        break;
+                    case this.pageEmojis.previous:
+                        id = this.activePage - 1;
+                        break;
+                    case this.pageEmojis.next:
+                        id = this.activePage + 1;
+                        break;
+                    default:
+                        break; // Make linter happy
+                }
+            }
+            if (id < 0 || id >= this.pages.length) {
+                // Out of bounds
+                return undefined;
+            }
+            page = id;
+        }
+
+        if (setActive) {
+            this.activePage = page;
+        }
+
+        return [
+            this.pages[page].text,
+            {
+                embed: this.pages[page].embed,
+                files: this.file ? [this.file] : undefined // TODO: support multiple files
+            }
+        ];
+    }
+
+    /**
+     * Checks if this reply has multiple pages.
+     * @returns {boolean} True if there are multiple pages; false otherwise.
+     */
+    hasPages() {
+        return this.pages.length > 1;
     }
 }
 

--- a/bot/modules/DiscordReplyPage.js
+++ b/bot/modules/DiscordReplyPage.js
@@ -1,0 +1,40 @@
+'use strict';
+
+
+/**
+ * Represents a reply page for Discord.
+ */
+class DiscordReplyPage {
+    /**
+     * Creates a new reply page.
+     * @param {string} text - The reply page text.
+     * @param {Object} [options] - The reply page options.
+     */
+    constructor(text, options) {
+        /**
+         * The message contents.
+         * @type {string}
+         */
+        this.text = text;
+
+        /**
+         * The embedded message.
+         * @type {RichEmbed|undefined}
+         */
+        this.embed = options && options.embed;
+
+        /**
+         * The associated emoji. If undefined, take default paging.
+         * @type {string|undefined}
+         */
+        this.emoji = options && options.emoji;
+
+        /**
+         * Extra data.
+         * @type {*}
+         */
+        this.data = options && options.data;
+    }
+}
+
+module.exports = DiscordReplyPage;

--- a/bot/modules/general/commands/Help.js
+++ b/bot/modules/general/commands/Help.js
@@ -4,6 +4,10 @@ const AutoRemoveMessage = require('../../../middleware/AutoRemoveMessage');
 
 const DiscordCommandError = require('../../../modules/DiscordCommandError');
 const DiscordCommand = require('../../../modules/DiscordCommand');
+const DiscordReplyMessage = require('../../../modules/DiscordReplyMessage');
+const DiscordReplyPage = require('../../../modules/DiscordReplyPage');
+
+const { splitMax } = require('../../../utils/String');
 
 
 class CommandHelp extends DiscordCommand {
@@ -44,14 +48,18 @@ class CommandHelp extends DiscordCommand {
         }
 
         // Reply with general help
-        const help = [];
+        let help = [];
         modules.forEach(module => {
             const moduleHelp = this._formatModuleHelp(message, module);
             if (moduleHelp) {
                 help.push(moduleHelp);
             }
         });
-        return l.t('module.general:help.response-all-help', { list: help.join('\n\n'), help: helpInvocation });
+        const helpLength = l.t('module.general:help.response-all-help').length;
+        help = splitMax(help.join('\n\n'), '\n', 2000 - helpLength).map(h => {
+            return new DiscordReplyPage(l.t('module.general:help.response-all-help', { list: h, help: helpInvocation }));
+        });
+        return new DiscordReplyMessage(help);
     }
 
     /**

--- a/bot/modules/general/commands/Help.js
+++ b/bot/modules/general/commands/Help.js
@@ -55,11 +55,23 @@ class CommandHelp extends DiscordCommand {
                 help.push(moduleHelp);
             }
         });
-        const helpLength = l.t('module.general:help.response-all-help').length;
-        help = splitMax(help.join('\n\n'), '\n', 2000 - helpLength).map(h => {
-            return new DiscordReplyPage(l.t('module.general:help.response-all-help', { list: h, help: helpInvocation }));
-        });
-        return new DiscordReplyMessage(help);
+        help = help.join('\n\n');
+
+        const helpLength = l.t('module.general:help.response-all-help-paged').length;
+        if (help.length > 2000 - helpLength) {
+            help = splitMax(help, '\n', 2000 - helpLength);
+            help = help.map((h, i) => {
+                return new DiscordReplyPage(l.t('module.general:help.response-all-help-paged', {
+                    list: h,
+                    help: helpInvocation,
+                    current_page: i + 1, // eslint-disable-line camelcase
+                    total_pages: help.length // eslint-disable-line camelcase
+                }));
+            });
+            return new DiscordReplyMessage(help);
+        }
+
+        return l.t('module.general:help.response-all-help', { list: help, help: helpInvocation });
     }
 
     /**

--- a/bot/utils/String.js
+++ b/bot/utils/String.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Splits a string into separate array entries based on the delimiter
+ * and the maximum amount of characters that may exist in every entry.
+ * @param {string} source - The string source.
+ * @param {string} delimiter - The delimiter.
+ * @param {number} maxCharacters - The maximum amount of characters per entry.
+ * @returns {Array} The resulting array.
+ */
+function splitMax(source, delimiter, maxCharacters) {
+    const split = [];
+    let pos = maxCharacters - 1;
+    let minPos = 0;
+    while (pos < source.length) {
+        while (source[pos] !== delimiter && pos > minPos) {
+            // We assume that the source contains at least 1 delimiter character every maxCharacters, if not, it's rip
+            pos--;
+        }
+        if (source[pos] !== delimiter) {
+            break;
+        }
+        split.push(source.substring(minPos, pos));
+        minPos = pos + 1;
+        pos += maxCharacters;
+    }
+    split.push(source.substring(minPos));
+    return split;
+}
+
+module.exports = {
+    splitMax
+};

--- a/locales/en-US/module.guildwars2.json
+++ b/locales/en-US/module.guildwars2.json
@@ -130,7 +130,7 @@
       "short-description": "Shows your raid progress",
       "long-description": "Shows your raid progress of this week."
     },
-    "raid-forsaken_thicket": "Forsaken Ticket",
+    "raid-forsaken_thicket": "Forsaken Thicket",
     "wing-spirit_vale": "Spirit Vale",
     "encounter-vale_guardian": "Vale Guardian",
     "encounter-spirit_woods": "Spirit Woods",
@@ -154,11 +154,17 @@
     "raid-unknown": "Raid {{id}}",
     "wing-unknown": "Wing {{id}}",
     "encounter-unknown": "Encounter {{id}}",
-    "response-title": "{{user}}'s weekly raid progress",
-    "response-raid-wing-field": "{{raid}}: {{wing}}",
-    "response-wing-field": "{{wing}}",
-    "response-encounter-done": "☑ {{encounter}}",
-    "response-encounter-missing": "➖ {{encounter}}"
+    "response-summary-title": "{{user}}'s weekly raid progress – To do",
+    "response-summary-wing": "**{{wing}}:** {{encounters}}",
+    "response-summary-done": "You have nothing left to do.",
+    "response-details-title": "{{user}}'s weekly raid progress – {{raid}}",
+    "response-details-raid-wing-field": "{{raid}}: {{wing}}",
+    "response-details-wing-field": "{{wing}}",
+    "response-details-encounter-done": "☑ {{encounter}}",
+    "response-details-encounter-missing": "➖ {{encounter}}",
+    "response-pages-title": "Pages",
+    "response-pages-description-summary": "📖 Summary",
+    "response-pages-description-raid": "{{emoji}} Detailed: {{description}}"
   },
   "sab": {
     "_meta": {


### PR DESCRIPTION
This adds support for very large replies by splitting it up in multiple smaller parts, a.k.a. pages. The original author of the message that executed the command will get the option to react to the reply. Reactions are used to determine which page should be showed at that time. After a few minutes of inactivity (currently set to 15 minutes), the reactions will cease to work.

This PR also includes the migration of the help and raids commands to make use of this new feature.
Closes #8